### PR TITLE
feat: include namespace as part of the config

### DIFF
--- a/charts/data-control-center/templates/secrets.yaml
+++ b/charts/data-control-center/templates/secrets.yaml
@@ -8,7 +8,10 @@
 # Set $secretData to existing secret data or generate a random one when not exists
 {{- $password = (get $secretData "CEPH_DASHBOARD_PASSWORD" | default (randAlphaNum 32)) -}}
 {{- end -}}
-{{- $config := merge .Values.config (dict "ceph" (dict "api" (dict "password" $password))) }}
+{{- $config := merge .Values.config (dict "ceph" (dict "api" (dict "password" $password))) -}}
+{{- if empty .Values.config.namespace -}}
+{{- $config = merge $config (dict "config" (dict "namespace" .Release.Namespace))) -}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/data-control-center/values.yaml
+++ b/charts/data-control-center/values.yaml
@@ -108,6 +108,7 @@ postInstallJob:
 
 # -- data-control-center config, documentation here: https://github.com/koor-tech/data-control-center/blob/main/docs/configuration.md#reference
 config:
+  namespace: 'rook-ceph'
   logLevel: 'INFO'
   mode: 'release'
   http:

--- a/charts/data-control-center/values.yaml
+++ b/charts/data-control-center/values.yaml
@@ -108,7 +108,7 @@ postInstallJob:
 
 # -- data-control-center config, documentation here: https://github.com/koor-tech/data-control-center/blob/main/docs/configuration.md#reference
 config:
-  namespace: 'rook-ceph'
+  namespace: # Defaults to current namespace
   logLevel: 'INFO'
   mode: 'release'
   http:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,7 @@
 # Please refer to the configuration documentation to learn
 # how to setup the config file.
 # https://github.com/koor-tech/data-control-center/blob/main/docs/configuration.md#reference
+namespace: 'rook-ceph'
 logLevel: 'DEBUG'
 # debug or release
 mode: 'debug'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ Changes to the config file are not auto detected, they require a (manual) restar
 
 ## Reference
 
-* `namespace`: The namespace the ceph cluster is running on. E.g. `'rook-ceph'`
+* `namespace`: The namespace the Rook Ceph cluster is running in. In most cases, this is `rook-ceph`. Defaults to `rook-ceph`.
 * `logLevel`: Can be `DEBUG`, `INFO`, `WARN` and `ERROR`. Defaults to `INFO`.
 * `mode`: Can be `debug` or `release`. Default: `release`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,7 @@ Changes to the config file are not auto detected, they require a (manual) restar
 
 ## Reference
 
+* `namespace`: The namespace the ceph cluster is running on. E.g. `'rook-ceph'`
 * `logLevel`: Can be `DEBUG`, `INFO`, `WARN` and `ERROR`. Defaults to `INFO`.
 * `mode`: Can be `debug` or `release`. Default: `release`.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,8 +53,9 @@ func LoadTest() (*Config, error) {
 }
 
 type Config struct {
-	LogLevel string `default:"INFO" yaml:"logLevel"`
-	Mode     string `default:"debug" yaml:"mode"`
+	Namespace string `default:"rook-ceph" yaml:"namespace"`
+	LogLevel  string `default:"INFO" yaml:"logLevel"`
+	Mode      string `default:"debug" yaml:"mode"`
 
 	HTTP   HTTP    `yaml:"http"`
 	JWT    JWT     `yaml:"jwt"`


### PR DESCRIPTION
Our demo cluster uses a different namespace than the `rook-ceph`