### PR TITLE
helm: increase the default number of replicas 

### DIFF
--- a/charts/data-control-center/README.md
+++ b/charts/data-control-center/README.md
@@ -97,7 +97,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `rbac.annotations` |  | `{}` |
 | `rbac.create` |  | `true` |
 | `rbac.name` |  | `""` |
-| `replicaCount` |  | `1` |
+| `replicaCount` |  | `2` |
 | `resources` |  | `{}` |
 | `securityContext` |  | `{}` |
 | `service.port` |  | `8282` |

--- a/charts/data-control-center/values.yaml
+++ b/charts/data-control-center/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 2
 
 image:
   repository: docker.io/koorinc/data-control-center


### PR DESCRIPTION
Tested changing the value on https://demo-staging.koor.tech/ , no issues.
I think we should deploy more than one replica so that we don't get 503 when accessing the dashboard on node failure. Feel free to drop if you don't think it's necessary to change the default.